### PR TITLE
ci: introduce GitHub Actions (issue #20, Top Risk 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+# Cancel superseded runs on the same ref (e.g. rapid pushes to a PR branch).
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least privilege: CI only needs to read the repository.
+permissions:
+  contents: read
+
+jobs:
+  # Validate the source lists and prove the committed build artifacts are not stale.
+  # Guards Risk #1 (cross-language casefold parity) by ensuring the compiled artifact
+  # always matches what the shared compiler produces from the source lists.
+  lists:
+    name: Lists (validate + freshness)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install validator dependencies
+        run: npm ci
+        working-directory: tools/validator
+
+      - name: Validate lists (regenerates manifest.json)
+        run: npm run validate
+        working-directory: tools/validator
+
+      - name: Compile lists (regenerates compiled artifact)
+        run: node tools/compile-lists/compile-lists.js
+
+      - name: Fail if committed artifacts are stale
+        run: git diff --exit-code -- tallman-lists/manifest.json tallman-lists/compiled/lists.compiled.json
+
+  # Build the C# implementation and run its tests, then run the canonical suite
+  # through the language-agnostic harness + adapter (the contract every Phase 4
+  # language will reuse). pwsh is preinstalled on ubuntu-latest, so the C# pre-build
+  # emitter (generate-embedded.ps1) runs without extra setup.
+  csharp:
+    name: C# build + tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Build and test (102 native + 84 canonical)
+        run: dotnet test languages/csharp/ToTallman.sln
+
+      - name: Install test-runner dependencies
+        run: npm ci
+        working-directory: tools/test-runner
+
+      - name: Canonical suite via shared harness + C# adapter
+        run: node tools/test-runner/run-canonical-tests.js languages/csharp/test-adapter.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,11 +64,13 @@ jobs:
       # Build the whole solution explicitly: `dotnet test` only builds the test
       # project and its dependencies, not the ToTallman.Demo project the shared
       # harness drives. The pre-build emitter (generate-embedded.ps1) runs here.
+      # Pin -c Debug explicitly on both steps: the test-adapter resolves the demo
+      # at bin/Debug/net8.0, so build and test must agree on the configuration.
       - name: Build solution (incl. demo used by the shared harness)
-        run: dotnet build languages/csharp/ToTallman.sln
+        run: dotnet build languages/csharp/ToTallman.sln -c Debug
 
       - name: Test (102 native + 84 canonical)
-        run: dotnet test languages/csharp/ToTallman.sln --no-build
+        run: dotnet test languages/csharp/ToTallman.sln -c Debug --no-build
 
       - name: Install test-runner dependencies
         run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,11 @@ jobs:
     name: Lists (validate + freshness)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install validator dependencies
         run: npm ci
@@ -51,15 +51,15 @@ jobs:
     name: C# build + tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       # Build the whole solution explicitly: `dotnet test` only builds the test
       # project and its dependencies, not the ToTallman.Demo project the shared

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,14 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Build and test (102 native + 84 canonical)
-        run: dotnet test languages/csharp/ToTallman.sln
+      # Build the whole solution explicitly: `dotnet test` only builds the test
+      # project and its dependencies, not the ToTallman.Demo project the shared
+      # harness drives. The pre-build emitter (generate-embedded.ps1) runs here.
+      - name: Build solution (incl. demo used by the shared harness)
+        run: dotnet build languages/csharp/ToTallman.sln
+
+      - name: Test (102 native + 84 canonical)
+        run: dotnet test languages/csharp/ToTallman.sln --no-build
 
       - name: Install test-runner dependencies
         run: npm ci

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 | 2. Canonical test suite | ✅ Complete |
 | 3. C# implementation | ✅ Complete — 84/84 canonical, 102/102 native |
 | 4. Multi-language (Python → JS → Java) | ⏳ Next — [#13](https://github.com/MattCordell/ToTallman/issues/13) |
-| 5. CI/CD | ⏳ Planned — [#14](https://github.com/MattCordell/ToTallman/issues/14) |
+| 5. CI/CD | 🚧 In progress — minimal CI live (build + canonical tests + artifact freshness); full pipeline [#14](https://github.com/MattCordell/ToTallman/issues/14) |
 | 6. Documentation & release | ⏳ Planned — [#15](https://github.com/MattCordell/ToTallman/issues/15) |
 
 Detailed, up-to-date work lives in [GitHub issues](https://github.com/MattCordell/ToTallman/issues).

--- a/languages/csharp/src/ToTallman.Demo/Program.cs
+++ b/languages/csharp/src/ToTallman.Demo/Program.cs
@@ -3,9 +3,9 @@ using ToTallman;
 
 namespace ToTallman.Demo
 {
-    class Program
+    internal class Program
     {
-        static int Main(string[] args)
+        private static int Main(string[] args)
         {
             // CLI mode for canonical test adapter
             if (args.Length >= 2 && (args[0] == "--input" || args[0] == "--input-base64"))
@@ -21,7 +21,7 @@ namespace ToTallman.Demo
         /// CLI mode for test adapter integration.
         /// Usage: ToTallman.Demo --input "text" [--list "LIST_ID"]
         /// </summary>
-        static int RunCliMode(string[] args)
+        private static int RunCliMode(string[] args)
         {
             try
             {
@@ -78,7 +78,7 @@ namespace ToTallman.Demo
         /// <summary>
         /// Interactive demonstration mode.
         /// </summary>
-        static int RunInteractiveMode()
+        private static int RunInteractiveMode()
         {
             Console.WriteLine("===========================================");
             Console.WriteLine("  ToTallman v2.0.0 - Medication Safety");
@@ -131,7 +131,7 @@ namespace ToTallman.Demo
         /// <summary>
         /// Demonstrates a Tallman conversion example.
         /// </summary>
-        static void DemoExample(string title, string input)
+        private static void DemoExample(string title, string input)
         {
             Console.WriteLine($"[{title}]");
             Console.WriteLine($"  Input:  {input}");

--- a/languages/csharp/src/ToTallman/ToTallman.csproj
+++ b/languages/csharp/src/ToTallman/ToTallman.csproj
@@ -25,7 +25,7 @@
       <!-- Detect PowerShell executable (cross-platform support) -->
       <PowerShellExe Condition="'$(OS)' == 'Windows_NT'">powershell</PowerShellExe>
       <PowerShellExe Condition="'$(OS)' != 'Windows_NT'">pwsh</PowerShellExe>
-      <EmbedListsScript>$(MSBuildProjectDirectory)\..\..\tools\generate-embedded.ps1</EmbedListsScript>
+      <EmbedListsScript>$(MSBuildProjectDirectory)/../../tools/generate-embedded.ps1</EmbedListsScript>
     </PropertyGroup>
 
     <Message Text="Emitting embedded Tallman lists from compiled artifact..." Importance="high" />

--- a/languages/csharp/test-adapter.js
+++ b/languages/csharp/test-adapter.js
@@ -4,9 +4,11 @@
 const { execSync } = require('child_process');
 const path = require('path');
 
-// Determine the path to the compiled demo executable
-// This assumes the demo has been built in Debug configuration
-const exePath = path.join(__dirname, 'src', 'ToTallman.Demo', 'bin', 'Debug', 'net8.0', 'ToTallman.Demo.exe');
+// Determine the path to the compiled demo assembly.
+// This assumes the demo has been built in Debug configuration.
+// We launch via the `dotnet` CLI (dotnet <dll>) rather than the native apphost
+// so the adapter works identically on Windows (.exe) and Linux/macOS (no extension) in CI.
+const dllPath = path.join(__dirname, 'src', 'ToTallman.Demo', 'bin', 'Debug', 'net8.0', 'ToTallman.Demo.dll');
 
 module.exports = {
     /**
@@ -21,8 +23,8 @@ module.exports = {
             // This handles newlines, quotes, unicode, and other special characters
             const base64Input = Buffer.from(input, 'utf8').toString('base64');
 
-            // Build command: ToTallman.Demo.exe --input-base64 "base64string" --list "LIST_ID"
-            const command = `"${exePath}" --input-base64 "${base64Input}" --list "${listId}"`;
+            // Build command: dotnet ToTallman.Demo.dll --input-base64 "base64string" --list "LIST_ID"
+            const command = `dotnet "${dllPath}" --input-base64 "${base64Input}" --list "${listId}"`;
 
             // Execute C# program and capture output
             const result = execSync(command, {

--- a/languages/csharp/tools/generate-embedded.ps1
+++ b/languages/csharp/tools/generate-embedded.ps1
@@ -17,8 +17,11 @@ $ErrorActionPreference = "Stop"
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path          # languages/csharp/tools
 $csharpDir = Split-Path -Parent $scriptDir                            # languages/csharp
 $projectRoot = Split-Path -Parent (Split-Path -Parent $csharpDir)     # repo root
-$artifactFile = Join-Path $projectRoot "tallman-lists\compiled\lists.compiled.json"
-$outputFile = Join-Path $csharpDir "src\ToTallman\EmbeddedTallmanLists.g.cs"
+# Build paths with [IO.Path]::Combine so the correct separator is used on every
+# OS (PowerShell 5.1 on Windows, pwsh on Linux/macOS in CI). Hardcoded backslashes
+# would be treated as literal filename characters under pwsh on Linux.
+$artifactFile = [System.IO.Path]::Combine($projectRoot, "tallman-lists", "compiled", "lists.compiled.json")
+$outputFile = [System.IO.Path]::Combine($csharpDir, "src", "ToTallman", "EmbeddedTallmanLists.g.cs")
 
 if (-not (Test-Path $artifactFile)) {
     Write-Error "Compiled list artifact not found: $artifactFile`nRun 'node tools/compile-lists/compile-lists.js' first."

--- a/tallman-lists/manifest.json
+++ b/tallman-lists/manifest.json
@@ -8,7 +8,7 @@
   {
     "id": "DEFAULT",
     "version": "20180819.0",
-    "entries": 199,
+    "entries": 202,
     "description": "Default aggregate Tallman list combining entries from multiple sources"
   },
   {

--- a/tools/validator/validate-schema.js
+++ b/tools/validator/validate-schema.js
@@ -66,9 +66,12 @@ function main() {
   const ajv = new Ajv({ allErrors: true });
   const validate = ajv.compile(schema);
 
-  // Find all JSON files in tallman-lists directory
+  // Find all JSON source lists in the tallman-lists directory.
+  // Exclude schema.json and the generated manifest.json (which is this tool's own
+  // output, not a source list) so the validator is idempotent on a fresh checkout.
+  // This mirrors the same exclusion in tools/compile-lists/compile-lists.js.
   const jsonFiles = fs.readdirSync(listsDir)
-    .filter(file => file.endsWith('.json') && file !== 'schema.json')
+    .filter(file => file.endsWith('.json') && file !== 'schema.json' && file !== 'manifest.json')
     .sort();
 
   if (jsonFiles.length === 0) {


### PR DESCRIPTION
Addresses **Top Risk 3** of #20: bring CI forward *before* the Phase 4 multi-language work, since CI is what prevents cross-language drift as languages are added.

## What this adds

`.github/workflows/ci.yml` — two `ubuntu-latest` jobs (triggered on push to `master`, all PRs, and manual dispatch):

- **`lists`** — validate the source lists, re-run the shared compiler, and **fail if the committed `manifest.json` / `lists.compiled.json` are stale** (the compiled-artifact freshness check; guards Risk #1, cross-language casefold parity).
- **`csharp`** — `dotnet test` (102 native + 84 canonical), then run the canonical suite through the language-agnostic `tools/test-runner` + C# adapter — the contract every Phase 4 language will plug into.

The cross-language **output-parity** check (the third Top Risk 3 item) is deferred by necessity — nothing to compare against with one language — but the shared harness it builds on is now exercised in CI.

## Supporting cross-platform fixes (so the C# pipeline runs on Linux CI)

- **`generate-embedded.ps1`** — build paths with `[IO.Path]::Combine` instead of hardcoded backslashes, which `pwsh` on Linux treats as literal filename characters. Still PowerShell 5.1-compatible.
- **`test-adapter.js`** — launch the demo via `dotnet <dll>` instead of the Windows-only `.exe` apphost.

## Incidental fix surfaced by the freshness check

`validate-schema.js` was validating its **own** generated `manifest.json` against the *list* schema, so `npm run validate` failed on any fresh checkout (where the committed manifest exists). Now excludes `manifest.json`, mirroring `compile-lists.js`. This surfaced a stale committed manifest (`DEFAULT` recorded 199 entries vs. the actual 202); regenerated to match the source lists.

## Verified locally (Windows)

- `npm run validate` → passes, idempotent
- `node tools/compile-lists/compile-lists.js` → compiled artifact clean (no drift)
- `dotnet test` → **102/102**
- `node tools/test-runner/run-canonical-tests.js languages/csharp/test-adapter.js` → **84/84**

Linux portability is proven by this PR's own CI run.

## Follow-ups (out of scope)

- Mark `lists` + `csharp` as required status checks (repo setting).
- Gitignore `EmbeddedTallmanLists.g.cs` (#20 smaller improvement).
- Implement the cross-language parity check when language #2 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)