### PR TITLE
test: audit and expand canonical test suite (issue #19)

### DIFF
--- a/tests/canonical/basic-replacement.json
+++ b/tests/canonical/basic-replacement.json
@@ -25,10 +25,10 @@
       "expected": "predniSONE and more predniSONE"
     },
     {
-      "description": "Multiple different drugs",
-      "input": "morphine and hydromorphone",
+      "description": "Multiple different drugs - one in list (converts), one not in any list (unchanged)",
+      "input": "aspirin and hydromorphone",
       "listId": "DEFAULT",
-      "expected": "morphine and HYDROmorphone"
+      "expected": "aspirin and HYDROmorphone"
     },
     {
       "description": "Drug at end of sentence with period",

--- a/tests/canonical/case-insensitive.json
+++ b/tests/canonical/case-insensitive.json
@@ -1,12 +1,6 @@
 {
   "tests": [
     {
-      "description": "All lowercase input",
-      "input": "prednisone",
-      "listId": "DEFAULT",
-      "expected": "predniSONE"
-    },
-    {
       "description": "All uppercase input",
       "input": "PREDNISONE",
       "listId": "DEFAULT",
@@ -31,13 +25,13 @@
       "expected": "predniSONE"
     },
     {
-      "description": "Multiple drugs with different cases",
+      "description": "Multiple drugs with different cases - MORPHINE normalizes to self-mapped form, HyDrOmOrPhOnE converts",
       "input": "MORPHINE and HyDrOmOrPhOnE",
       "listId": "DEFAULT",
       "expected": "morphine and HYDROmorphone"
     },
     {
-      "description": "Sentence with mixed case drug names",
+      "description": "Sentence with mixed case drug names - self-mapped entry (morphine) and converting entry (prednisone) both normalize",
       "input": "Patient takes PredniSONE and MorPhiNe daily",
       "listId": "DEFAULT",
       "expected": "Patient takes predniSONE and morphine daily"

--- a/tests/canonical/multi-list.json
+++ b/tests/canonical/multi-list.json
@@ -7,27 +7,33 @@
       "expected": "predniSONE"
     },
     {
-      "description": "FDA list - predniSONE (lowercase input)",
+      "description": "FDA list - prednisone (same capitalization as DEFAULT)",
       "input": "prednisone",
       "listId": "FDA",
       "expected": "predniSONE"
     },
     {
-      "description": "AU list - amiodarone",
+      "description": "AU list - amiodarone (AU-specific entry)",
       "input": "amiodarone",
       "listId": "AU",
       "expected": "amiODAROne"
     },
     {
-      "description": "ISMP list - morphine (not in ISMP list)",
+      "description": "ISMP list - morphine (self-mapping entry in ISMP, no Tall Man caps)",
       "input": "morphine",
       "listId": "ISMP",
       "expected": "morphine"
     },
     {
-      "description": "NZ list - morphine (in NZ list)",
+      "description": "NZ list - morphine (not in NZ list -> unchanged)",
       "input": "morphine",
       "listId": "NZ",
+      "expected": "morphine"
+    },
+    {
+      "description": "DEFAULT list - morphine (self-mapping entry in DEFAULT, no Tall Man caps -> unchanged)",
+      "input": "morphine",
+      "listId": "DEFAULT",
       "expected": "morphine"
     },
     {
@@ -49,13 +55,13 @@
       "expected": "vinCRISTine"
     },
     {
-      "description": "FDA list - vinCRIStine (different capitalization than AU)",
+      "description": "FDA list - vinCRIStine (different capitalization than AU vinCRISTine)",
       "input": "vincristine",
       "listId": "FDA",
       "expected": "vinCRIStine"
     },
     {
-      "description": "DEFAULT list - drug not in any list",
+      "description": "DEFAULT list - drug not in any list (aspirin -> unchanged)",
       "input": "aspirin",
       "listId": "DEFAULT",
       "expected": "aspirin"
@@ -65,6 +71,24 @@
       "input": "notadrug",
       "listId": "AU",
       "expected": "notadrug"
+    },
+    {
+      "description": "NZ list - foliNIc acid (positive NZ-only match)",
+      "input": "folinic acid",
+      "listId": "NZ",
+      "expected": "foliNIc acid"
+    },
+    {
+      "description": "DEFAULT list - SOLU-medrol (lowercase m in medrol)",
+      "input": "solu-medrol",
+      "listId": "DEFAULT",
+      "expected": "SOLU-medrol"
+    },
+    {
+      "description": "ISMP list - SOLU-Medrol (capital M differs from DEFAULT SOLU-medrol)",
+      "input": "solu-medrol",
+      "listId": "ISMP",
+      "expected": "SOLU-Medrol"
     }
   ]
 }

--- a/tests/canonical/multi-word.json
+++ b/tests/canonical/multi-word.json
@@ -83,6 +83,48 @@
       "input": "test-prednisone-test",
       "listId": "DEFAULT",
       "expected": "test-predniSONE-test"
+    },
+    {
+      "description": "3-word entry match - methylprednisolone SODIUM SUCCINate (NZ list, lowercase input)",
+      "input": "methylprednisolone sodium succinate",
+      "listId": "NZ",
+      "expected": "methylprednisolone SODIUM SUCCINate"
+    },
+    {
+      "description": "3-word entry match in sentence (NZ list)",
+      "input": "Administer methylprednisolone sodium succinate intravenously",
+      "listId": "NZ",
+      "expected": "Administer methylprednisolone SODIUM SUCCINate intravenously"
+    },
+    {
+      "description": "3-word entry match - mixed case input normalizes (NZ list)",
+      "input": "Methylprednisolone Sodium Succinate",
+      "listId": "NZ",
+      "expected": "methylprednisolone SODIUM SUCCINate"
+    },
+    {
+      "description": "Multi-word case variant - all uppercase (MS CONTIN -> MS Contin)",
+      "input": "MS CONTIN",
+      "listId": "DEFAULT",
+      "expected": "MS Contin"
+    },
+    {
+      "description": "Multi-word case variant - title case (Ms Contin -> MS Contin)",
+      "input": "Ms Contin",
+      "listId": "DEFAULT",
+      "expected": "MS Contin"
+    },
+    {
+      "description": "Multi-word fallback - first word of ms contin entry present but second word differs (no partial match)",
+      "input": "ms aspirin",
+      "listId": "DEFAULT",
+      "expected": "ms aspirin"
+    },
+    {
+      "description": "Multi-word fallback - first word of multi-word entry is not a standalone entry",
+      "input": "ms",
+      "listId": "DEFAULT",
+      "expected": "ms"
     }
   ]
 }

--- a/tests/canonical/punctuation.json
+++ b/tests/canonical/punctuation.json
@@ -53,6 +53,30 @@
       "input": "prednisone, morphine; hydromorphone.",
       "listId": "DEFAULT",
       "expected": "predniSONE, morphine; HYDROmorphone."
+    },
+    {
+      "description": "No-space punctuation adjacency - comma with no surrounding spaces (spec 8.3)",
+      "input": "prednisone,prednisone",
+      "listId": "DEFAULT",
+      "expected": "predniSONE,predniSONE"
+    },
+    {
+      "description": "Possessive apostrophe is a word boundary - drug name before apostrophe-s converts",
+      "input": "prednisone's",
+      "listId": "DEFAULT",
+      "expected": "predniSONE's"
+    },
+    {
+      "description": "Multi-word drug in parentheses - parentheses are word boundaries",
+      "input": "(ms contin)",
+      "listId": "DEFAULT",
+      "expected": "(MS Contin)"
+    },
+    {
+      "description": "Hyphenated drug with trailing comma - comma is word boundary after second component",
+      "input": "solu-medrol,",
+      "listId": "DEFAULT",
+      "expected": "SOLU-medrol,"
     }
   ]
 }

--- a/tests/canonical/unicode-casefolding.json
+++ b/tests/canonical/unicode-casefolding.json
@@ -1,37 +1,37 @@
 {
   "tests": [
     {
-      "description": "Basic Latin - lowercase",
-      "input": "morphine",
+      "description": "ASCII drug name matched via casefold - lowercase input converts",
+      "input": "prednisone",
       "listId": "DEFAULT",
-      "expected": "morphine"
+      "expected": "predniSONE"
     },
     {
-      "description": "Basic Latin - uppercase",
-      "input": "MORPHINE",
+      "description": "ASCII drug name matched via casefold - uppercase input normalizes and converts",
+      "input": "PREDNISONE",
       "listId": "DEFAULT",
-      "expected": "morphine"
+      "expected": "predniSONE"
     },
     {
-      "description": "German ß (sharp s) - should handle casefolding",
-      "input": "straße morphine",
+      "description": "Non-Latin surrounding text (German sharp-s) does not affect ASCII drug matching",
+      "input": "straße prednisone",
       "listId": "DEFAULT",
-      "expected": "straße morphine"
+      "expected": "straße predniSONE"
     },
     {
-      "description": "Greek letters in context",
-      "input": "Σ morphine",
+      "description": "Non-Latin surrounding text (Greek) does not affect ASCII drug matching",
+      "input": "Σ prednisone",
       "listId": "DEFAULT",
-      "expected": "Σ morphine"
+      "expected": "Σ predniSONE"
     },
     {
-      "description": "Cyrillic characters in context",
-      "input": "Д morphine В",
+      "description": "Non-Latin surrounding text (Cyrillic) does not affect ASCII drug matching",
+      "input": "Д prednisone В",
       "listId": "DEFAULT",
-      "expected": "Д morphine В"
+      "expected": "Д predniSONE В"
     },
     {
-      "description": "Mixed scripts",
+      "description": "Mixed scripts - CJK surrounding text does not affect ASCII drug matching",
       "input": "测试 prednisone test",
       "listId": "DEFAULT",
       "expected": "测试 predniSONE test"

--- a/tests/canonical/unicode-casefolding.json
+++ b/tests/canonical/unicode-casefolding.json
@@ -2,15 +2,15 @@
   "tests": [
     {
       "description": "ASCII drug name matched via casefold - lowercase input converts",
-      "input": "prednisone",
+      "input": "norfloxacin",
       "listId": "DEFAULT",
-      "expected": "predniSONE"
+      "expected": "NORfloxacin"
     },
     {
       "description": "ASCII drug name matched via casefold - uppercase input normalizes and converts",
-      "input": "PREDNISONE",
+      "input": "NORFLOXACIN",
       "listId": "DEFAULT",
-      "expected": "predniSONE"
+      "expected": "NORfloxacin"
     },
     {
       "description": "Non-Latin surrounding text (German sharp-s) does not affect ASCII drug matching",

--- a/tests/canonical/unicode-nfc.json
+++ b/tests/canonical/unicode-nfc.json
@@ -1,37 +1,37 @@
 {
   "tests": [
     {
-      "description": "Simple ASCII - baseline",
+      "description": "Simple ASCII baseline - NFC normalization applied but no effect on ASCII input",
       "input": "prednisone",
       "listId": "DEFAULT",
       "expected": "predniSONE"
     },
     {
-      "description": "Text with combining diacritical marks (if drug names had them)",
+      "description": "NFC normalization of surrounding text with combining diacritical marks does not affect ASCII drug matching",
       "input": "café prednisone naïve",
       "listId": "DEFAULT",
       "expected": "café predniSONE naïve"
     },
     {
-      "description": "Unicode normalization test - é (precomposed U+00E9)",
+      "description": "Precomposed é (U+00E9) in surrounding text - NFC input, ASCII drug still matches",
       "input": "résumé prednisone",
       "listId": "DEFAULT",
       "expected": "résumé predniSONE"
     },
     {
-      "description": "Unicode normalization test - é (decomposed e + ́  U+0065 U+0301)",
+      "description": "Decomposed é (U+0065 U+0301) in surrounding text - NFC normalizes it, ASCII drug still matches",
       "input": "résumé prednisone",
       "listId": "DEFAULT",
       "expected": "résumé predniSONE"
     },
     {
-      "description": "Non-ASCII characters in surrounding text",
-      "input": "Ü morphine Ñ",
+      "description": "Non-ASCII diacritical characters in surrounding text do not affect ASCII drug matching",
+      "input": "Ü prednisone Ñ",
       "listId": "DEFAULT",
-      "expected": "Ü morphine Ñ"
+      "expected": "Ü predniSONE Ñ"
     },
     {
-      "description": "Drug name remains unchanged with emoji context",
+      "description": "Emoji in surrounding text does not affect ASCII drug matching",
       "input": "💊 prednisone 💊",
       "listId": "DEFAULT",
       "expected": "💊 predniSONE 💊"


### PR DESCRIPTION
## Summary

Closes #19. Audits and expands the canonical test suite that forms the cross-language contract for all future language implementations (Phase 4).

**Net change: 84 → 98 canonical tests; `dotnet test` 108 → 122; 100% pass.**

### Part A — Fixes to existing tests

| File | Change |
|------|--------|
| `multi-list.json` | Fixed wrong description "NZ list - morphine (in NZ list)" — morphine is **not** in NZ. Added explicit DEFAULT and NZ self-map tests; added NZ `foliNIc acid` positive match; added ISMP `SOLU-Medrol` vs DEFAULT `SOLU-medrol` cross-list capitalisation difference |
| `basic-replacement.json` | Switched ambiguous `morphine` in "Multiple different drugs" to `aspirin` (genuinely absent from all lists) |
| `case-insensitive.json` | Removed pure duplicate lowercase test (identical to basic-replacement test 1); clarified self-map descriptions for morphine tests |
| `unicode-casefolding.json` | Relabelled as "non-Latin passthrough" tests; replaced self-mapping `morphine` with `prednisone` so the drug visibly changes and each test is meaningful |
| `unicode-nfc.json` | Clarified descriptions (NFC applies to surrounding text; entries are ASCII-only); swapped `morphine` for `prednisone` in test 5 |

### Part B — New scenarios

| File | New tests |
|------|-----------|
| `multi-word.json` | 3-word NZ entry (`methylprednisolone SODIUM SUCCINate`) — standalone, in-sentence, and mixed-case variants; `MS CONTIN` / `Ms Contin` case variants; multi-word fallback (`ms aspirin` unchanged, `ms` alone unchanged) |
| `punctuation.json` | No-space adjacency `prednisone,prednisone` (spec 8.3); possessive apostrophe `prednisone's`; multi-word in parentheses `(ms contin)`; hyphenated with trailing comma `solu-medrol,` |

### Deferred (documented)

- **Greedy longest-match precedence** — requires a single-word entry that is also the first word of a multi-word entry in the same list; no such overlap exists in real data.
- **Unicode matched-entry casefold/NFC** — impossible while all entries are ASCII (spec 3.2 / Phase 5 #14).

## Test plan

- [x] `npm test` in `tools/test-runner` — schema validation: **98/98**
- [x] `node tools/test-runner/run-canonical-tests.js languages/csharp/test-adapter.js` — **98/98 (100%)**
- [x] `dotnet test languages/csharp/ToTallman.sln` — **122/122 passed**

🤖 Generated with [Claude Code](https://claude.ai/claude-code)