### PR TITLE
build(java): bump junit-jupiter 5.10.2 → 5.14.4, harden major-skip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -87,6 +87,14 @@ updates:
       java-deps:
         update-types: ['minor', 'patch']
     open-pull-requests-limit: 5
+    ignore:
+      # JUnit 6.x and Spotless 3.x require JDK 17 — blocked until the Java floor
+      # moves off 11 (see issue #50). Major-skip is here rather than comment state
+      # so it survives any Dependabot comment pruning.
+      - dependency-name: "org.junit.jupiter:junit-jupiter"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "com.diffplug.spotless:spotless-maven-plugin"
+        update-types: ["version-update:semver-major"]
 
   # C# implementation
   - package-ecosystem: nuget

--- a/languages/java/pom.xml
+++ b/languages/java/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.10.2</version>
+            <version>5.14.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Summary

- Bumps `org.junit.jupiter:junit-jupiter` **5.10.2 → 5.14.4** (latest Java-8-baseline 5.x release) in `languages/java/pom.xml`
- Adds explicit `ignore` entries for `junit-jupiter` and `spotless-maven-plugin` major versions in `.github/dependabot.yml`, making the JDK-17 major-skip durable in config rather than reliant on Dependabot comment state

## Background

Dependabot PRs #42 (JUnit 6.x) and #41 (Spotless 3.x) were closed because both majors require JDK 17, conflicting with the **Java 11** support floor (`maven.compiler.release = 11`, CI matrix `['11','17']`). The `@dependabot ignore` comment-based state that suppressed those majors is invisible and can be pruned; the `ignore:` block in dependabot.yml is the durable fix.

## Test plan

- [ ] CI `java` job runs `mvn verify` on JDK **11** and **17** matrix (Spotless check + JUnit 5 tests + canonical suite via adapter)
- [ ] Embedded-lists freshness check passes (no drift in `EmbeddedTallmanLists.java`)
- [ ] No JUnit 6.x or Spotless 3.x Dependabot PRs reappear after merge

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)