### PR TITLE
fix(js): upgrade TypeScript 5 -> 6, fix TS6.0 build failures

### DIFF
--- a/languages/js/package-lock.json
+++ b/languages/js/package-lock.json
@@ -17,7 +17,7 @@
         "@typescript-eslint/parser": "^8.62.0",
         "eslint": "^10.5.0",
         "prettier": "^3.0.0",
-        "typescript": "^5.0.0",
+        "typescript": "^6.0.0",
         "typescript-eslint": "^8.62.0"
       },
       "engines": {
@@ -1198,9 +1198,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/languages/js/package.json
+++ b/languages/js/package.json
@@ -38,7 +38,7 @@
     "@typescript-eslint/parser": "^8.62.0",
     "eslint": "^10.5.0",
     "prettier": "^3.0.0",
-    "typescript": "^5.0.0",
+    "typescript": "^6.0.0",
     "typescript-eslint": "^8.62.0"
   }
 }

--- a/languages/js/tsconfig.base.json
+++ b/languages/js/tsconfig.base.json
@@ -11,6 +11,7 @@
     "sourceMap": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
   }
 }

--- a/languages/js/tsconfig.cjs.json
+++ b/languages/js/tsconfig.cjs.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "module": "Node16",
     "moduleResolution": "Node16",
+    "rootDir": "./src",
     "outDir": "./dist/cjs"
   },
   "include": ["src/**/*.ts"]

--- a/languages/js/tsconfig.esm.json
+++ b/languages/js/tsconfig.esm.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    "rootDir": "./src",
     "outDir": "./dist/esm"
   },
   "include": ["src/**/*.ts"]


### PR DESCRIPTION
## Summary

- Bumps `typescript` devDep `^5.0.0 -> ^6.0.0` in `languages/js`.
- Adds `types: [node]` to `tsconfig.base.json` -- TS 6.0 no longer auto-includes `@types/node`, causing `TS2591` errors on `process`/`Buffer` in `cli.ts`.
- Adds `rootDir: ./src` to `tsconfig.cjs.json` and `tsconfig.esm.json` -- TS 6.0 now requires this to be explicit (was implicit from `include`), fixing `TS5011`.

Emit target (`ES2020`), `lib`, and `engines.node` (`>=18`) are **unchanged** -- library runtime contract preserved.

## Test plan

- [x] `npm run build` (both `tsconfig.cjs.json` and `tsconfig.esm.json`) compiles cleanly under TS 6.0.3
- [x] `npm run typecheck` -- clean
- [x] `npm run lint` -- clean
- [x] `npm run format:check` -- clean
- [x] `npm test` -- 18/18 pass
- [x] `npm run test:canonical` -- 99/99 pass

Closes #53. Supersedes dependabot #38.

Generated with [Claude Code](https://claude.com/claude-code)
