### PR TITLE
docs(sources): confirm comparator intent with ACSQHC & ISMP (issue #57)

### DIFF
--- a/tallman-lists/sources/AU/CORRESPONDENCE.md
+++ b/tallman-lists/sources/AU/CORRESPONDENCE.md
@@ -1,0 +1,44 @@
+# AU (ACSQHC) — Authority Correspondence
+
+This file records direct correspondence with the Australian Commission on Safety and
+Quality in Health Care (the Commission / ACSQHC) regarding interpretation of entries in
+the National Mixed-Case Lettering List. It is a traceability record supporting the source
+extract decisions in this directory.
+
+---
+
+## 2026 — Intent of all-lowercase entries (`fluoxetine`, `morphine`, `tretinoin`)
+
+**Issue:** [#57](https://github.com/MattCordell/ToTallman/issues/57) — Investigate intent of
+all-lowercase entries currently marked as comparators.
+
+**Question put to the Commission:** For `fluoxetine`, `morphine` and `tretinoin`, are the
+all-lowercase entries intentional always-lowercase mixed-case forms, or are they plain
+LASA comparators documented for context only?
+
+**Response from the Australian Commission on Safety and Quality in Health Care (verbatim):**
+
+> Thank you for contacting the Australian Commission on Safety and Quality in Health Care
+> (the Commission) and for your enquiry regarding the National Mixed-Case Lettering List.
+>
+> The entries you have identified – fluoxetine, morphine and tretinoin, are included as
+> comparators within the look-alike, sound-alike (LASA) pairs. They provide context for the
+> mixed-case lettering applied to the paired medicine names that have been identified as
+> requiring differentiation.
+>
+> As you may be aware, the Commission's [National Mixed-Case Lettering List](https://www.safetyandquality.gov.au/publications-and-resources/resource-library/national-mixed-case-lettering-list)
+> is not intended to be an exhaustive list of all LASA medicine names. Health service
+> organisations may choose to apply 'mixed-case lettering' to additional medicine pairs,
+> following endorsement through their local medicines governance processes.
+>
+> Further guidance on the principles for applying 'mixed-case' lettering, including risk
+> assessment processes and application to locally identified LASA medicine names can be found
+> in 'Mixed case lettering': Principles for application.
+>
+> I hope this is helpful. Please feel free to reach out should you have any further enquiries.
+
+**Resolution:** Interpretation 1 (comparator) confirmed. `fluoxetine`, `morphine` and
+`tretinoin` are LASA comparators provided for context only — the Commission has **not**
+assigned a mixed-case (Tall Man) form to them. The current treatment is correct: these rows
+retain the `comparator` flag in `20240400.0.csv` and are **excluded** from the built TML
+output. Input forms of these drugs are returned unchanged by the runtime algorithm.

--- a/tallman-lists/sources/AU/meta.json
+++ b/tallman-lists/sources/AU/meta.json
@@ -16,5 +16,6 @@
   "licence_notes": "Verbatim redistribution with attribution permitted for non-commercial use. No derivative works. Commercial use requires separate permission from ACSQHC (communications@safetyandquality.gov.au). The archived PDF is redistributed verbatim here under CC BY-NC-ND 4.0.",
   "monitoring": "Check annually at the source URL above. Most recent update was April 2024 (renamed from 'National Tall Man Lettering List').",
   "notes": "List was renamed from 'National Tall Man Lettering List' to 'National Mixed-Case Lettering List' in the April 2024 revision. Structured in tables: Table 1 (general LASA pairs), Table 2 (oncology), Table 3 (drug classes), Table 4 (mab suffix), Table 5 (nib/gib suffix). Explicitly intended for AMT (Australian Medicines Terminology) integration.",
-  "extract_file": "20240400.0.csv"
+  "extract_file": "20240400.0.csv",
+  "correspondence_file": "CORRESPONDENCE.md"
 }

--- a/tallman-lists/sources/ISMP-SUPP/CORRESPONDENCE.md
+++ b/tallman-lists/sources/ISMP-SUPP/CORRESPONDENCE.md
@@ -1,0 +1,43 @@
+# ISMP — Authority Correspondence
+
+This file records direct correspondence with the Institute for Safe Medication Practices
+(ISMP) regarding interpretation of entries in the ISMP List of Look-Alike Drug Names. It is
+a traceability record supporting the source extract decisions in this directory.
+
+---
+
+## 2026 — Intent of all-lowercase entries (`leucovorin`, `morphine`, `penicillin`, `tretinoin`)
+
+**Issue:** [#57](https://github.com/MattCordell/ToTallman/issues/57) — Investigate intent of
+all-lowercase entries currently marked as comparators.
+
+**Question put to ISMP:** For `leucovorin`, `morphine`, `penicillin` and `tretinoin`, are the
+all-lowercase entries intentional always-lowercase Tall Man forms, or are they plain LASA
+comparators documented for context only?
+
+**Response from ISMP (verbatim):**
+
+> Thank you for reaching out. And, thank you for trying to operationalize tall man lettering
+> in electronic systems.
+>
+> We use and encourage the use of the letter casing as you see in the list. For the names
+> that are in all lower case, we do not have a tall men recommendation. For example, we
+> deliberately do not use tall man lettering for morphine as there really are no good options
+> to highlight difference between morphine and the "-morphone" part of HYDROmorphone as they
+> are almost identical. We rely on the distinctive "HYDRO-" part of HYDROmorphone while keeping
+> morphine all lower case. Tretinoin is another good example of this with tretinoin fully
+> contained within ISOtretinoin.
+>
+> I hope this helps. Please let me know if you have any other questions.
+
+**Resolution:** Interpretation 1 (comparator) confirmed. For the all-lowercase entries
+(`leucovorin`, `morphine`, `penicillin`, `tretinoin`), ISMP has **no Tall Man recommendation** —
+they deliberately keep these names lowercase and rely on the distinctive capitalised portion
+of the *paired* name (e.g. the `HYDRO-` of HYDROmorphone, the `ISO-` of ISOtretinoin) to
+create contrast. The current treatment is correct: these rows retain the `comparator` flag in
+`20230100.0.csv` and are **excluded** from the built TML output. Input forms of these drugs are
+returned unchanged by the runtime algorithm.
+
+**Note on licensing:** ISMP also affirmed they "use and encourage the use of the letter casing
+as you see in the list." See `meta.json` `licence_notes` for redistribution constraints on the
+ISMP source document itself.

--- a/tallman-lists/sources/ISMP-SUPP/meta.json
+++ b/tallman-lists/sources/ISMP-SUPP/meta.json
@@ -16,5 +16,6 @@
   "licence_notes": "CAUTION: Internal reproduction with attribution permitted; other use requires written permission from ISMP. The archived PDF is stored for transcription reference only. Confirm with ISMP before publishing this archived PDF in a public repository; consider storing only the citation + checksum rather than the binary if permission cannot be obtained.",
   "monitoring": "Updated following periodic ISMP surveys and Medication Safety Alert releases. January 2023 was the most recent full revision. Check ismp.org for announcements.",
   "notes": "This extract covers TABLE 2 ONLY (ISMP supplementary entries not in the FDA list). Table 1 of the ISMP document is identical to the FDA list and is covered by sources/FDA/. The combined ISMP list (FDA + ISMP-SUPP) is derived deterministically by tools/build-lists. The January 2023 update added seven new name pairs including cycloPHOSphamide, droPERidol/droNABinol, dexAMETHasone/dexmedeTOMIDine, and pyRIDostigmine/PHYSostigmine. Brand name entries are marked with flag 'brand' in the extract CSV.",
-  "extract_file": "20230100.0.csv"
+  "extract_file": "20230100.0.csv",
+  "correspondence_file": "CORRESPONDENCE.md"
 }

--- a/tallman-lists/sources/README.md
+++ b/tallman-lists/sources/README.md
@@ -38,7 +38,7 @@ Columns: `form`, `group`, `category`, `flags`, `page_ref`, `notes`
 
 | Flag | Meaning |
 |------|---------|
-| `comparator` | Plain-text LASA partner with no TML form assigned. Documented here for traceability but **excluded from the TML output**. Must be verified against source and either removed or assigned a correct TML form. |
+| `comparator` | Plain-text LASA partner with no TML form assigned. Documented here for traceability but **excluded from the TML output**. The intent of these entries was confirmed directly with ACSQHC and ISMP (see each authority's `CORRESPONDENCE.md`): they are deliberate context-only comparators, not always-lowercase TML forms, and input is returned unchanged at runtime. |
 | `exception_rule` | Authority explicitly excluded this drug from TML application (e.g. NZ `*`-marked entries). Documented but **excluded from output**. |
 | `discontinued` | Drug withdrawn from market in country of authority. Retained per source list; may be removed in a future revision. |
 | `brand` | Brand name entry (not INN/generic). |


### PR DESCRIPTION
## Summary

Resolves the open question in #57. Both authorities were contacted and have responded; this PR records their correspondence and confirms the provisional treatment was correct.

**Both authorities confirmed interpretation 1 (plain LASA comparator)** for the all-lowercase entries — these are NOT deliberate always-lowercase TML forms:

- **ACSQHC (AU)** — `fluoxetine`, `morphine`, `tretinoin`: "included as comparators within the look-alike, sound-alike (LASA) pairs. They provide context for the mixed-case lettering applied to the paired medicine names."
- **ISMP** — `leucovorin`, `morphine`, `penicillin`, `tretinoin`: "for the names that are in all lower case, we do not have a tall man recommendation"; they rely on the distinctive capitalised portion of the *paired* name (e.g. `HYDRO-` of HYDROmorphone, `ISO-` of ISOtretinoin).

## Consequence

The provisional `comparator` treatment (keep flag, exclude from output, return input unchanged at runtime) is **correct**. **No CSV / build / runtime changes are required** — the `always_lowercase` flag and upper/lower exception path contemplated in the issue are not needed.

## Changes

- Add `CORRESPONDENCE.md` to `sources/AU/` and `sources/ISMP-SUPP/` with the verbatim authority responses and resolution notes.
- Add a `correspondence_file` field to each `meta.json` for discoverability.
- Update the `comparator` flag definition in `sources/README.md` to record that the intent is now authority-confirmed.

## Gate

This unblocks the gate noted in #57 (provisional comparator assumption) ahead of v2 publication / #56.

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)