### PR TITLE
feat(parity): harden cross-language parity guarantees (closes #61)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,18 @@
 * text=auto
 
 ###############################################################################
+# Pin LF on generated/compiled/source-data files so freshness checks
+# (git diff --exit-code in CI) are stable across Windows and Linux contributors.
+# The emitters all produce \n; eol=lf makes the contract explicit and
+# guarantees checkout-to-LF everywhere so local regeneration never shows a
+# spurious diff from the committed state.
+###############################################################################
+*.json  text eol=lf
+*.py    text eol=lf
+*.java  text eol=lf
+*.ts    text eol=lf
+
+###############################################################################
 # Set default behavior for command prompt diff.
 #
 # This is need for earlier builds of msysgit that does not have it on by

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,9 @@ jobs:
     runs-on: ubuntu-latest
     # `python` here refers to the matrix job; GitHub Actions waits for ALL
     # matrix variants to succeed before treating the job as done.
-    needs: [csharp, python, java, js]
+    # `lists` is included so this job never runs against unvalidated or stale
+    # source lists / compiled artifacts (freshness is proven in the lists job).
+    needs: [lists, csharp, python, java, js]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -281,6 +283,15 @@ jobs:
           node-version: '24'
           cache: 'npm'
           cache-dependency-path: languages/js/package-lock.json
+
+      # Defense-in-depth: re-run compile-lists and fail if the committed compiled
+      # artifact is stale. The lists job already proves this for the same commit,
+      # but repeating it here ensures the parity job is always working from a
+      # provably fresh compiled artifact even if dependency ordering ever changes.
+      - name: Verify compiled artifact is fresh
+        run: |
+          node tools/compile-lists/compile-lists.js
+          git diff --exit-code -- tallman-lists/compiled/lists.compiled.json
 
       # The C# adapter spawns `dotnet ToTallman.Demo.dll`; rebuild here so the
       # binary is present in this job's workspace.

--- a/tallman-lists/schema.json
+++ b/tallman-lists/schema.json
@@ -30,10 +30,11 @@
     },
     "entries": {
       "type": "array",
-      "description": "Array of drug names with Tallman lettering (canonical output form)",
+      "description": "Array of drug names with Tallman lettering (canonical output form). Entries must be ASCII-only (letters, spaces, hyphens) so cross-language casefold parity is guaranteed (spec §3.2).",
       "items": {
         "type": "string",
-        "minLength": 1
+        "minLength": 1,
+        "pattern": "^[A-Za-z][A-Za-z -]*$"
       },
       "minItems": 1,
       "uniqueItems": true

--- a/tools/compile-lists/compile-lists.js
+++ b/tools/compile-lists/compile-lists.js
@@ -44,6 +44,17 @@ function compileList(filePath) {
 
   for (const entry of data.entries) {
     const normalized = entry.normalize('NFC');
+
+    // Defensive ASCII check: all four language runtimes fold case with different
+    // functions that agree only for ASCII input (spec §3.2). Fail loudly here so
+    // a non-ASCII entry can never reach the embedded artifacts, even if the validator
+    // is bypassed (the two tools are independently runnable).
+    if (!/^[\x00-\x7F]+$/.test(normalized)) {
+      throw new Error(
+        `Non-ASCII entry "${entry}" in list ${data.id} violates the ASCII-only ` +
+        `parity invariant (spec §3.2). Run the validator to catch this earlier.`);
+    }
+
     const key = casefoldKey(normalized);
 
     if (seen.has(key)) {

--- a/tools/parity-check/run-parity-check.js
+++ b/tools/parity-check/run-parity-check.js
@@ -11,6 +11,15 @@
 // Exit codes:
 //   0 - All adapters agree (or fewer than 2 adapters found - parity deferred)
 //   1 - Parity failure: at least one adapter produced different output
+//
+// NOTE: This tool tests already-built artifacts. It does NOT rebuild from
+// source before comparing. In CI the language jobs rebuild each implementation
+// and the parity job re-verifies the compiled artifact before running this
+// script. When running locally, build each language first:
+//   dotnet build languages/csharp/ToTallman.sln -c Debug
+//   pip install -e languages/python
+//   node languages/java/tools/embed-lists.js && mvn -f languages/java/pom.xml package -DskipTests
+//   npm ci && npm run build  (in languages/js/)
 
 const fs = require('fs');
 const path = require('path');

--- a/tools/validator/validate-schema.js
+++ b/tools/validator/validate-schema.js
@@ -150,13 +150,14 @@ function validateFile(filePath, validate) {
 }
 
 function validateEntries(data, fileName) {
-  // Check for duplicates (case-insensitive)
+  // Check for duplicates using the same key derivation as the compiler:
+  // NFC-normalize then toLowerCase (spec §3.2, casefold = NFC + toLowerCase).
   const seen = new Map();
   const duplicates = [];
 
   for (let i = 0; i < data.entries.length; i++) {
     const entry = data.entries[i];
-    const lowerEntry = entry.toLowerCase();
+    const lowerEntry = entry.normalize('NFC').toLowerCase();
 
     if (seen.has(lowerEntry)) {
       duplicates.push({


### PR DESCRIPTION
## Summary

Implements all three items from #61 — B3 (gitattributes), B1 (ASCII invariant), and B2 (parity job freshness).

### B3 — `.gitattributes` eol=lf (commit 1)
- Adds explicit `eol=lf` for `*.json`, `*.py`, `*.java`, `*.ts`
- `git add --renormalize` confirmed zero artifact churn — all committed files were already LF-normalised

### B1 — ASCII-only invariant enforcement (commit 2)
- **`tallman-lists/schema.json`**: adds `pattern: "^[A-Za-z][A-Za-z -]*$"` to entry items — makes the ASCII + letter-only constraint machine-checkable at the schema layer (all 5 current lists pass)
- **`tools/compile-lists/compile-lists.js`**: adds a defensive ASCII assertion that throws loudly if a non-ASCII entry reaches the compiler even when the validator is bypassed (the two tools are independently runnable)
- **`tools/validator/validate-schema.js`**: fixes the duplicate-key check to use `NFC + toLowerCase` instead of bare `toLowerCase`, matching the compiler's exact casefold key derivation (spec §3.2)

### B2 — Parity job freshness (commit 2)
- **`ci.yml`**: adds `lists` to the parity job's `needs` — previously parity could run even if the lists/compiled-artifact freshness job failed
- **`ci.yml`**: adds a "Verify compiled artifact is fresh" step in the parity job (re-runs compile-lists + git diff) as defense-in-depth
- **`tools/parity-check/run-parity-check.js`**: documents the fresh-build assumption in the header comment so local users know to build each language before running the tool

## Test plan

- [ ] Validator passes all 5 lists with the new schema pattern (`npm run validate` in `tools/validator`)
- [ ] Compiler runs clean (`node tools/compile-lists/compile-lists.js` from repo root)
- [ ] CI passes (all jobs including the updated parity job)
- [ ] Manually verify that an entry with a non-ASCII character would be rejected by both the schema (AJV validation error) and the compiler (thrown Error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)